### PR TITLE
Add Build-Timestamp to NAR MANIFEST.MF

### DIFF
--- a/src/hatch_datavolo_nar/builder.py
+++ b/src/hatch_datavolo_nar/builder.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import datetime
 import io
 import os
 import sys
@@ -22,6 +23,8 @@ from hatchling.metadata.core import ProjectMetadata
 
 class NarBundle:
     DIRECTORY_MODE = 0o755
+
+    BUILD_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
     def __init__(self, zip_descriptor: ZipFile):
         self.zip_descriptor = zip_descriptor
@@ -50,9 +53,13 @@ class NarBundle:
         manifest_dir = "META-INF"
         self.mkdir(manifest_dir)
 
+        current_timestamp = datetime.datetime.now(datetime.UTC)
+        build_timestamp = current_timestamp.strftime(self.BUILD_TIMESTAMP_FORMAT)
+
         manifest_lines = [
             "Manifest-Version: 1.0",
             "Created-By: hatch-datavolo-nar",
+            f"Build-Timestamp: {build_timestamp}",
             f"Nar-Id: {metadata.core.raw_name}-nar",
             f"Nar-Group: {metadata.core.raw_name}",
             f"Nar-Version: {metadata.version}",

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import datetime
 import os
 from pathlib import Path
 from zipfile import ZipFile
@@ -155,8 +156,12 @@ def assert_manifest_found(nar: ZipFile, project_name: str, project_version: str)
     manifest_binary = nar.read("META-INF/MANIFEST.MF")
     manifest = str(manifest_binary, encoding="utf-8")
 
+    now = datetime.datetime.now(datetime.UTC)
+    partial_timestamp = now.strftime("%Y-%m-%dT")
+
     assert "Manifest-Version: 1.0" in manifest
     assert "Created-By: hatch-datavolo-nar" in manifest
+    assert f"Build-Timestamp: {partial_timestamp}" in manifest
     assert f"Nar-Id: {project_name}-nar" in manifest
     assert f"Nar-Group: {project_name}" in manifest
     assert f"Nar-Version: {project_version}" in manifest


### PR DESCRIPTION
This pull request adds the `Build-Timestamp` entry to the `MANIFEST.MF` produced when packaging NAR bundles.

The timestamp itself is set based on the current date and time in UTC, and the string format follows the ISO 8601 format that the Apache NiFi NAR Maven Plugin applies in the [NarMojo](https://github.com/apache/nifi-maven/blob/main/src/main/java/org/apache/nifi/NarMojo.java).